### PR TITLE
[API] Organizer can set group category

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ The live site can be viewed [here]().
 * List groups with its events
 * Organizer can create an event
 * User can create a group
+* Organizer can set Category for group
+
 
 ## Screenshots
 

--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -1,0 +1,11 @@
+class CategoriesController < ApplicationController
+  def index
+    categories = Category.all
+    render json: categories
+  end
+
+  def show
+    category = Category.find(params[:id])
+    render json: category
+  end
+end

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -2,12 +2,6 @@ class GroupsController < ApplicationController
   before_action :authenticate_user!, only: [:create]
 
   def index
-    if params[:category_id]
-      groups = Group.where(category_id: params[:category_id])
-    else
-      groups = Group.all
-    end
-    render json: groups
   end
 
   def show
@@ -26,7 +20,7 @@ class GroupsController < ApplicationController
 
   private
   def group_params
-    params.require(:group).permit(:name)
+    params.require(:group).permit(:name, :category_id)
   end
 
 end

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -2,6 +2,12 @@ class GroupsController < ApplicationController
   before_action :authenticate_user!, only: [:create]
 
   def index
+    if params[:category_id]
+      groups = Group.where(category_id: params[:category_id])
+    else
+      groups = Group.all
+    end
+    render json: groups
   end
 
   def show

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,3 +1,4 @@
 class Category < ApplicationRecord
+  validates_presence_of :name
   has_many :groups
 end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,0 +1,3 @@
+class Category < ApplicationRecord
+  has_many :groups
+end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -4,6 +4,7 @@ class Group < ApplicationRecord
   validates_presence_of :name
   has_many :members, class_name: 'Membership'
   has_many :events
+  belongs_to :category
 
   def future_events
     events.future_events

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,11 +7,11 @@ Rails.application.routes.draw do
     resources :attendees, only: [:create]
   end
 
-  resources :categories, only: [:index, :show] do
-    resources :groups, only: [:index, :show, :create] do
-      resources :memberships, only: [:create]
-      resources :events, only: [:index, :create]
-    end
+  resources :categories, only: [:index, :show] 
+
+  resources :groups, only: [:index, :show, :create] do
+    resources :memberships, only: [:create]
+    resources :events, only: [:index, :create]
   end
   
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,9 +7,11 @@ Rails.application.routes.draw do
     resources :attendees, only: [:create]
   end
 
-  resources :groups, only: [:index, :show, :create] do
-    resources :memberships, only: [:create]
-    resources :events, only: [:index, :create]
+  resources :categories, only: [:index, :show] do
+    resources :groups, only: [:index, :show, :create] do
+      resources :memberships, only: [:create]
+      resources :events, only: [:index, :create]
+    end
   end
   
 end

--- a/db/migrate/20190203141358_create_categories.rb
+++ b/db/migrate/20190203141358_create_categories.rb
@@ -1,0 +1,9 @@
+class CreateCategories < ActiveRecord::Migration[5.2]
+  def change
+    create_table :categories do |t|
+      t.string :name
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20190203142633_add_columns_to_groups.rb
+++ b/db/migrate/20190203142633_add_columns_to_groups.rb
@@ -1,0 +1,5 @@
+class AddColumnsToGroups < ActiveRecord::Migration[5.2]
+  def change
+    add_column :groups, :category_id, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,51 +10,15 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_02_03_141358) do
+ActiveRecord::Schema.define(version: 2019_02_03_142633) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
-
-  create_table "active_storage_attachments", force: :cascade do |t|
-    t.string "name", null: false
-    t.string "record_type", null: false
-    t.bigint "record_id", null: false
-    t.bigint "blob_id", null: false
-    t.datetime "created_at", null: false
-    t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
-    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
-  end
-
-  create_table "active_storage_blobs", force: :cascade do |t|
-    t.string "key", null: false
-    t.string "filename", null: false
-    t.string "content_type"
-    t.text "metadata"
-    t.bigint "byte_size", null: false
-    t.string "checksum", null: false
-    t.datetime "created_at", null: false
-    t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
-  end
 
   create_table "categories", force: :cascade do |t|
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-  end
-
-  create_table "delayed_jobs", force: :cascade do |t|
-    t.integer "priority", default: 0, null: false
-    t.integer "attempts", default: 0, null: false
-    t.text "handler", null: false
-    t.text "last_error"
-    t.datetime "run_at"
-    t.datetime "locked_at"
-    t.datetime "failed_at"
-    t.string "locked_by"
-    t.string "queue"
-    t.datetime "created_at"
-    t.datetime "updated_at"
-    t.index ["priority", "run_at"], name: "delayed_jobs_priority"
   end
 
   create_table "events", force: :cascade do |t|
@@ -63,10 +27,7 @@ ActiveRecord::Schema.define(version: 2019_02_03_141358) do
     t.datetime "updated_at", null: false
     t.bigint "group_id"
     t.date "date"
-    t.text "description"
-    t.string "location"
-    t.string "organizer"
-    t.string "date_and_time"
+    t.integer "organizer"
     t.index ["group_id"], name: "index_events_on_group_id"
   end
 
@@ -74,6 +35,7 @@ ActiveRecord::Schema.define(version: 2019_02_03_141358) do
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "category_id"
   end
 
   create_table "memberships", force: :cascade do |t|
@@ -124,7 +86,6 @@ ActiveRecord::Schema.define(version: 2019_02_03_141358) do
     t.index ["uid", "provider"], name: "index_users_on_uid_and_provider", unique: true
   end
 
-  add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "events", "groups"
   add_foreign_key "memberships", "groups"
   add_foreign_key "memberships", "users"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,52 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_01_29_184737) do
+ActiveRecord::Schema.define(version: 2019_02_03_141358) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "active_storage_attachments", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "record_type", null: false
+    t.bigint "record_id", null: false
+    t.bigint "blob_id", null: false
+    t.datetime "created_at", null: false
+    t.index ["blob_id"], name: "index_active_storage_attachments_on_blob_id"
+    t.index ["record_type", "record_id", "name", "blob_id"], name: "index_active_storage_attachments_uniqueness", unique: true
+  end
+
+  create_table "active_storage_blobs", force: :cascade do |t|
+    t.string "key", null: false
+    t.string "filename", null: false
+    t.string "content_type"
+    t.text "metadata"
+    t.bigint "byte_size", null: false
+    t.string "checksum", null: false
+    t.datetime "created_at", null: false
+    t.index ["key"], name: "index_active_storage_blobs_on_key", unique: true
+  end
+
+  create_table "categories", force: :cascade do |t|
+    t.string "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "delayed_jobs", force: :cascade do |t|
+    t.integer "priority", default: 0, null: false
+    t.integer "attempts", default: 0, null: false
+    t.text "handler", null: false
+    t.text "last_error"
+    t.datetime "run_at"
+    t.datetime "locked_at"
+    t.datetime "failed_at"
+    t.string "locked_by"
+    t.string "queue"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+    t.index ["priority", "run_at"], name: "delayed_jobs_priority"
+  end
 
   create_table "events", force: :cascade do |t|
     t.string "title"
@@ -21,6 +63,10 @@ ActiveRecord::Schema.define(version: 2019_01_29_184737) do
     t.datetime "updated_at", null: false
     t.bigint "group_id"
     t.date "date"
+    t.text "description"
+    t.string "location"
+    t.string "organizer"
+    t.string "date_and_time"
     t.index ["group_id"], name: "index_events_on_group_id"
   end
 
@@ -78,6 +124,7 @@ ActiveRecord::Schema.define(version: 2019_01_29_184737) do
     t.index ["uid", "provider"], name: "index_users_on_uid_and_provider", unique: true
   end
 
+  add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "events", "groups"
   add_foreign_key "memberships", "groups"
   add_foreign_key "memberships", "users"

--- a/spec/factories/categories.rb
+++ b/spec/factories/categories.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :category do
+    name { "MyString" }
+  end
+end

--- a/spec/factories/groups.rb
+++ b/spec/factories/groups.rb
@@ -1,5 +1,6 @@
 FactoryBot.define do
   factory :group do
     name { "GroupName" }
+    category
   end
 end

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Category, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -7,7 +7,7 @@ describe Category, type: :model do
   end
 
   describe 'Associations' do
-    it { is_expected.to has_many :groups }
+    it { is_expected.to have_many :groups }
   end
 
   describe 'Validations' do

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -1,5 +1,22 @@
-require 'rails_helper'
+# frozen_string_literal: true
 
-RSpec.describe Category, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+describe Category, type: :model do
+
+  describe 'DB table' do
+    it { is_expected.to have_db_column :name }
+  end
+
+  describe 'Associations' do
+    it { is_expected.to has_many :groups }
+  end
+
+  describe 'Validations' do
+    it { is_expected.to validate_presence_of :name }
+  end
+
+  describe 'Factory' do
+    it 'is valid' do
+      expect(create(:category)).to be_valid
+    end
+  end
 end

--- a/spec/requests/organizer_can_set_group_category_spec.rb
+++ b/spec/requests/organizer_can_set_group_category_spec.rb
@@ -10,7 +10,7 @@ describe 'GET /cagegories/:id/groups' do
   end
 
   before do
-    get "/categories/#{category_1.id}/groups", headers: headers
+    get "/categories", headers: headers
   end
 
   it 'lists groups belonging to the categories' do
@@ -22,7 +22,7 @@ describe 'GET /cagegories/:id/groups' do
     expect(response).to have_http_status(200)
   end
 
-  it 'returns 3 groups' do
-    expect(response_json.count).to eq 3
+  it 'returns 2 categories' do
+    expect(response_json.count).to eq 2
   end
 end

--- a/spec/requests/organizer_can_set_group_category_spec.rb
+++ b/spec/requests/organizer_can_set_group_category_spec.rb
@@ -14,15 +14,15 @@ describe 'GET /cagegories/:id/groups' do
   end
 
   it 'lists groups belonging to the categories' do
-    ids_list = category_1.groups.map(&:category.id)
+    ids_list = category_1.groups.map(&:category_id)
     expect(ids_list).not_to include category_2.id
   end
 
-  it 'returns 200' do 
+  it 'returns 200' do
     expect(response).to have_http_status(200)
   end
 
   it 'returns 3 groups' do
-    expect(response_json['groups'].count).to eq 3
+    expect(response_json.count).to eq 3
   end
 end

--- a/spec/requests/organizer_can_set_group_category_spec.rb
+++ b/spec/requests/organizer_can_set_group_category_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe 'GET /cagegories/:id/groups' do
+describe 'GET /categories' do
   let!(:category_1) { create(:category) } 
   let!(:category_2) { create(:category) } 
 

--- a/spec/requests/organizer_can_set_group_category_spec.rb
+++ b/spec/requests/organizer_can_set_group_category_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+describe 'GET /cagegories/:id/groups' do
+  let!(:category_1) { create(:category) } 
+  let!(:category_2) { create(:category) } 
+
+  let!(:group) do 
+    3.times { create(:group, category: category_1) }
+    3.times { create(:group, category: category_2) }
+  end
+
+  before do
+    get "/categories/#{category_1.id}/groups", headers: headers
+  end
+
+  it 'lists groups belonging to the categories' do
+    ids_list = category_1.groups.map(&:category.id)
+    expect(ids_list).not_to include category_2.id
+  end
+
+  it 'returns 200' do 
+    expect(response).to have_http_status(200)
+  end
+
+  it 'returns 3 groups' do
+    expect(response_json['groups'].count).to eq 3
+  end
+end

--- a/spec/requests/organizer_can_set_group_category_spec.rb
+++ b/spec/requests/organizer_can_set_group_category_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe 'GET /categories' do
+describe 'GET /categories/:id' do
   let!(:category_1) { create(:category) } 
   let!(:category_2) { create(:category) } 
 

--- a/spec/requests/user_can_create_group_spec.rb
+++ b/spec/requests/user_can_create_group_spec.rb
@@ -3,12 +3,14 @@
 describe 'POST /groups' do
   let(:user) { create(:user) }
 
+  let(:category) { create(:category) }
+
   describe 'POST req with valid credentials' do
     let(:user_credentials) { user.create_new_auth_token }
     let(:headers) { { HTTP_ACCEPT: 'application/json' }.merge!(user_credentials) }
     
     before do
-      post "/groups", params: { group: {name: 'coding'} }, headers: headers
+      post "/groups", params: { group: {name: 'coding', category_id: category.id } }, headers: headers
     end
 
     it 'responds with success message' do


### PR DESCRIPTION
## Description
As an Organizer
In order to make my group easier to find
I would like to be able to set a Category for my group

## PivotalTracker
[Link](https://www.pivotaltracker.com/story/show/163682227)

## Tasks
- Write request spec
- Create Category model with #index
- Create Endpoint
- Associate with Group