### PR TITLE
[API]Organizer can set additional group info

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,7 @@ gem 'rack-cors', require: 'rack/cors'
 gem 'active_model_serializers'
 gem 'devise_token_auth'
 gem 'uglifier', '>= 1.3.0'
+gem 'faker'
 
 group :development, :test do
   gem 'pry-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -83,6 +83,8 @@ GEM
     factory_bot_rails (4.11.1)
       factory_bot (~> 4.11.1)
       railties (>= 3.0.0)
+    faker (1.9.1)
+      i18n (>= 0.7)
     ffi (1.10.0)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
@@ -228,6 +230,7 @@ DEPENDENCIES
   coveralls
   devise_token_auth
   factory_bot_rails
+  faker
   listen (>= 3.0.5, < 3.2)
   pg (>= 0.18, < 2.0)
   pry-rails

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -20,7 +20,7 @@ class GroupsController < ApplicationController
 
   private
   def group_params
-    params.require(:group).permit(:name, :category_id, :description, :location)
+    params.require(:group).permit(:name, :category_id, :description, :location, :organizer_id)
   end
 
 end

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -20,7 +20,7 @@ class GroupsController < ApplicationController
 
   private
   def group_params
-    params.require(:group).permit(:name, :category_id)
+    params.require(:group).permit(:name, :category_id, :description, :location)
   end
 
 end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -6,6 +6,8 @@ class Group < ApplicationRecord
   has_many :events
   belongs_to :category
 
+  belongs_to :organizer, class_name: 'User'
+
   def future_events
     events.future_events
   end

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Group < ApplicationRecord
-  validates_presence_of :name
+  validates_presence_of :name, :description, :location
   has_many :members, class_name: 'Membership'
   has_many :events
   belongs_to :category

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -13,4 +13,5 @@ class User < ApplicationRecord
   has_many :rsvps
   has_many :memberships
   has_many :groups, through: :memberships
+  has_many :organized_groups, class_name: 'Group', foreign_key: 'organizer_id'
 end

--- a/app/serializers/groups/show_serializer.rb
+++ b/app/serializers/groups/show_serializer.rb
@@ -1,5 +1,5 @@
 class Groups::ShowSerializer < ActiveModel::Serializer
-  attributes :id, :name
+  attributes :id, :name, :description, :location
   has_many :future_events, serializer: Events::ForGroupCollectionSerializer
   has_many :past_events, serializer: Events::ForGroupCollectionSerializer
 end

--- a/db/migrate/20190203142633_add_columns_to_groups.rb
+++ b/db/migrate/20190203142633_add_columns_to_groups.rb
@@ -1,5 +1,7 @@
 class AddColumnsToGroups < ActiveRecord::Migration[5.2]
   def change
     add_column :groups, :category_id, :string
+    add_column :groups, :description, :text
+    add_column :groups, :location, :string
   end
 end

--- a/db/migrate/20190203142633_add_columns_to_groups.rb
+++ b/db/migrate/20190203142633_add_columns_to_groups.rb
@@ -3,5 +3,6 @@ class AddColumnsToGroups < ActiveRecord::Migration[5.2]
     add_column :groups, :category_id, :string
     add_column :groups, :description, :text
     add_column :groups, :location, :string
+    add_column :groups, :organizer_id, :integer
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -37,6 +37,7 @@ ActiveRecord::Schema.define(version: 2019_02_03_142633) do
     t.string "category_id"
     t.text "description"
     t.string "location"
+    t.integer "organizer_id"
   end
 
   create_table "memberships", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -27,7 +27,6 @@ ActiveRecord::Schema.define(version: 2019_02_03_142633) do
     t.datetime "updated_at", null: false
     t.bigint "group_id"
     t.date "date"
-    t.integer "organizer"
     t.index ["group_id"], name: "index_events_on_group_id"
   end
 
@@ -36,6 +35,8 @@ ActiveRecord::Schema.define(version: 2019_02_03_142633) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "category_id"
+    t.text "description"
+    t.string "location"
   end
 
   create_table "memberships", force: :cascade do |t|

--- a/spec/factories/groups.rb
+++ b/spec/factories/groups.rb
@@ -1,6 +1,8 @@
 FactoryBot.define do
   factory :group do
     name { "GroupName" }
+    description { "GroupDescription" }
+    location { "GroupLocation" }
     category
   end
 end

--- a/spec/factories/groups.rb
+++ b/spec/factories/groups.rb
@@ -4,5 +4,6 @@ FactoryBot.define do
     description { "GroupDescription" }
     location { "GroupLocation" }
     category
+    association :organizer, factory: :user
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :user do
-    email { 'random@random.com' }
+    email { Faker::Internet.email }
     password { 'password' }
   end
 end

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -3,10 +3,15 @@
 RSpec.describe Group, type: :model do
   describe 'DB table' do
     it { is_expected.to have_db_column :name }
+    it { is_expected.to have_db_column :description }
+    it { is_expected.to have_db_column :location }
+
   end
 
   describe 'Validations' do
     it { is_expected.to validate_presence_of :name }
+    it { is_expected.to validate_presence_of :description }
+    it { is_expected.to validate_presence_of :location }
   end
 
   describe 'Associations' do

--- a/spec/models/group_spec.rb
+++ b/spec/models/group_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe Group, type: :model do
   describe 'Associations' do
     it { is_expected.to have_many :members }
     it { is_expected.to have_many :events }
+    it { is_expected.to belong_to :organizer }
   end
 
   describe 'Factory' do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -21,4 +21,17 @@ describe User, type: :model do
       expect(create(:user)).to be_valid
     end
   end
+
+  describe '#organized_groups' do
+    let!(:group){ create(:group, organizer: subject) }
+
+    subject { create(:user) }
+
+    it 'includes the group' do
+      ids = subject.organized_groups.map(&:id)
+      expect(ids).to include group.id
+    end
+  end
 end
+
+

--- a/spec/requests/user_can_create_group_spec.rb
+++ b/spec/requests/user_can_create_group_spec.rb
@@ -42,6 +42,7 @@ describe 'POST /groups' do
     it 'assigns group to the right category' do
       expect(@last_group.category).to eq category
     end
+   
   end
 
   describe 'POST req with no group name' do

--- a/spec/requests/user_can_create_group_spec.rb
+++ b/spec/requests/user_can_create_group_spec.rb
@@ -16,6 +16,7 @@ describe 'POST /groups' do
                                         description: "This is about coding",
                                         organizer_id: user.id
                                         } }, headers: headers
+      @last_group = Group.last
     end
 
     it 'responds with success message' do
@@ -24,6 +25,22 @@ describe 'POST /groups' do
 
     it 'responds with status 200' do
       expect(response).to have_http_status 200
+    end
+
+    it 'stores the name' do
+      expect(@last_group.name).to eq 'coding'
+    end
+  
+    it 'stores the description' do
+      expect(@last_group.description).to eq 'This is about coding'
+    end
+
+    it 'stores the location' do
+      expect(@last_group.location).to eq 'Stockholm'
+    end
+  
+    it 'assigns group to the right category' do
+      expect(@last_group.category).to eq category
     end
   end
 

--- a/spec/requests/user_can_create_group_spec.rb
+++ b/spec/requests/user_can_create_group_spec.rb
@@ -10,7 +10,11 @@ describe 'POST /groups' do
     let(:headers) { { HTTP_ACCEPT: 'application/json' }.merge!(user_credentials) }
     
     before do
-      post "/groups", params: { group: {name: 'coding', category_id: category.id } }, headers: headers
+      post "/groups", params: { group: {name: 'coding', 
+                                        category_id: category.id,
+                                        location: "Stockholm",
+                                        description: "This is about coding"
+                                        } }, headers: headers
     end
 
     it 'responds with success message' do

--- a/spec/requests/user_can_create_group_spec.rb
+++ b/spec/requests/user_can_create_group_spec.rb
@@ -13,7 +13,8 @@ describe 'POST /groups' do
       post "/groups", params: { group: {name: 'coding', 
                                         category_id: category.id,
                                         location: "Stockholm",
-                                        description: "This is about coding"
+                                        description: "This is about coding",
+                                        organizer_id: user.id
                                         } }, headers: headers
     end
 

--- a/spec/serializers/groups/show_serializer_spec.rb
+++ b/spec/serializers/groups/show_serializer_spec.rb
@@ -10,7 +10,7 @@ describe Groups::ShowSerializer, type: :serializer do
   subject { JSON.parse(serialization.to_json) }
 
   it 'contains relevant keys' do
-    expected_keys = %w[id name future_events past_events]
+    expected_keys = %w[id name description location future_events past_events]
     expect(subject.keys).to match expected_keys
   end
 end


### PR DESCRIPTION
## Description
As an Organizer
In order to engage relevant audience
I would like to be able to set additional group info

## PivotalTracker
[Link](https://www.pivotaltracker.com/story/show/163513895)

## Tasks
- Adds attributes
- Associate organizer with groups
- Updates validation, factory and spec
- Updates Serializer for groups show action


## Gems added
- Faker


